### PR TITLE
Fixing the way zlib & sqlite3 are included

### DIFF
--- a/src/corelibs/U2Core/U2Core.pri
+++ b/src/corelibs/U2Core/U2Core.pri
@@ -8,9 +8,11 @@ UGENE_RELATIVE_DESTDIR = ''
 QT += network xml
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-DEFINES+= QT_FATAL_ASSERT BUILDING_U2CORE_DLL
+DEFINES+=UGENE_MIN_VERSION_SQLITE=$${UGENE_MIN_VERSION_SQLITE}
+DEFINES+=UGENE_MIN_VERSION_MYSQL=$${UGENE_MIN_VERSION_MYSQL}
+DEFINES+=QT_FATAL_ASSERT BUILDING_U2CORE_DLL
+
 use_bundled_zlib() {
-    INCLUDEPATH += ../../libs_3rdparty/zlib/src
     LIBS += -lzlib
 } else {
     LIBS += -lz
@@ -20,8 +22,6 @@ unix: QMAKE_CXXFLAGS += -Wno-char-subscripts
 
 LIBS += -L../../_release
 LIBS += -lugenedb
-
-INCLUDEPATH += ../../libs_3rdparty/sqlite3/src
 
 !debug_and_release|build_pass {
 

--- a/src/corelibs/U2Core/src/dbi/U2SqlHelpers.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2SqlHelpers.cpp
@@ -25,7 +25,7 @@
 #include <U2Core/U2DbiUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <sqlite3.h>
+#include <3rdparty/sqlite3/sqlite3.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Core/src/io/ZlibAdapter.cpp
+++ b/src/corelibs/U2Core/src/io/ZlibAdapter.cpp
@@ -25,12 +25,7 @@
 
 #include "ZlibAdapter.h"
 
-//using 3rd-party zlib (not included in ugene bundle) on *nix
-#if defined(Q_OS_UNIX)
-#include <zlib.h>
-#else
-#include "zlib.h"
-#endif
+#include <3rdparty/zlib/zlib.h>
 
 #include <assert.h>
 

--- a/src/include/3rdparty/sqlite3/sqlite3.h
+++ b/src/include/3rdparty/sqlite3/sqlite3.h
@@ -1,0 +1,1 @@
+#include "../../../libs_3rdparty/sqlite3/src/sqlite3.h"

--- a/src/include/3rdparty/zlib/zlib.h
+++ b/src/include/3rdparty/zlib/zlib.h
@@ -1,0 +1,7 @@
+#ifdef UGENE_USE_BUNDLED_ZLIB
+#include "../../../libs_3rdparty/zlib/src/zlib.h"
+#else
+#include <zlib.h>
+#endif
+
+

--- a/src/libs_3rdparty/samtools/samtools.pri
+++ b/src/libs_3rdparty/samtools/samtools.pri
@@ -10,8 +10,9 @@ win32 : DEFINES += _USE_MATH_DEFINES "inline=__inline" "__func__=__FUNCTION__" "
 LIBS += -L../../_release
 
 use_bundled_zlib() {
-    INCLUDEPATH += ../zlib/src
     LIBS += -lzlib
+} else {
+    LIBS += -lz
 }
 
 macx {

--- a/src/libs_3rdparty/samtools/src/samtools/bam.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bam.h
@@ -61,7 +61,7 @@ typedef BGZF *bamFile;
 #define bam_seek(fp, pos, dir) bgzf_seek(fp, pos, dir)
 #else
 #define BAM_TRUE_OFFSET
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 typedef gzFile bamFile;
 #define bam_open(fn, mode) gzopen(fn, mode)
 #define bam_dopen(fd, mode) gzdopen(fd, mode)

--- a/src/libs_3rdparty/samtools/src/samtools/bam_import.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_import.c
@@ -1,4 +1,4 @@
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>

--- a/src/libs_3rdparty/samtools/src/samtools/bam_rmdup.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_rmdup.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #include <unistd.h>
 #include "sam.h"
 

--- a/src/libs_3rdparty/samtools/src/samtools/bcftools/bcf.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bcftools/bcf.h
@@ -31,7 +31,7 @@
 #define BCF_VERSION "0.1.17-dev (r973:277)"
 
 #include <stdint.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 
 #ifndef BCF_LITE
 #include "bgzf.h"

--- a/src/libs_3rdparty/samtools/src/samtools/bcftools/call1.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bcftools/call1.c
@@ -1,7 +1,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <math.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #include <errno.h>
 #include "bcf.h"
 #include "prob1.h"

--- a/src/libs_3rdparty/samtools/src/samtools/bcftools/vcf.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bcftools/vcf.c
@@ -1,4 +1,4 @@
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/libs_3rdparty/samtools/src/samtools/bedidx.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bedidx.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 
 #ifdef _WIN32
 #define drand48() ((double)rand() / RAND_MAX)

--- a/src/libs_3rdparty/samtools/src/samtools/bgzf.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bgzf.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #ifdef _USE_KNETFILE
 #include "knetfile.h"
 #endif

--- a/src/libs_3rdparty/samtools/src/samtools/phase.c
+++ b/src/libs_3rdparty/samtools/src/samtools/phase.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <math.h>
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #include "bam.h"
 #include "errmod.h"
 

--- a/src/libs_3rdparty/samtools/src/samtools/razf.h
+++ b/src/libs_3rdparty/samtools/src/samtools/razf.h
@@ -35,7 +35,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "zlib.h"
+#include <3rdparty/zlib/zlib.h>
 
 #ifdef _USE_KNETFILE
 #include "knetfile.h"

--- a/src/plugins/biostruct3d_view/src/gl2ps/gl2ps.cpp
+++ b/src/plugins/biostruct3d_view/src/gl2ps/gl2ps.cpp
@@ -72,7 +72,7 @@
 #endif
 
 #if defined(GL2PS_HAVE_ZLIB)
-#include <zlib.h>
+#include <3rdparty/zlib/zlib.h>
 #endif
 
 #if defined(GL2PS_HAVE_LIBPNG)

--- a/src/plugins/dbi_bam/src/BAMFormat.cpp
+++ b/src/plugins/dbi_bam/src/BAMFormat.cpp
@@ -19,12 +19,7 @@
  * MA 02110-1301, USA.
  */
 
-//using 3rd-party zlib (not included in ugene bundle) on *nix
-#if defined(Q_OS_UNIX)
-#include <zlib.h>
-#else
-#include "zlib.h"
-#endif
+#include <3rdparty/zlib/zlib.h>
 
 #include <U2Core/DocumentModel.h>
 #include <U2Core/L10n.h>

--- a/src/plugins/dbi_bam/src/BgzfReader.h
+++ b/src/plugins/dbi_bam/src/BgzfReader.h
@@ -22,12 +22,7 @@
 #ifndef _U2_BAM_BGZF_READER_H_
 #define _U2_BAM_BGZF_READER_H_
 
-//using 3rd-party zlib (not included in ugene bundle) on *nix
-#if defined(Q_OS_UNIX)
-#include <zlib.h>
-#else
-#include "zlib.h"
-#endif
+#include <3rdparty/zlib/zlib.h>
 
 #include <U2Core/IOAdapter.h>
 #include "VirtualOffset.h"

--- a/src/plugins/dbi_bam/src/BgzfWriter.h
+++ b/src/plugins/dbi_bam/src/BgzfWriter.h
@@ -22,12 +22,7 @@
 #ifndef _U2_BAM_BGZF_WRITER_H_
 #define _U2_BAM_BGZF_WRITER_H_
 
-//using 3rd-party zlib (not included in ugene bundle) on *nix
-#if defined(Q_OS_UNIX)
-#include <zlib.h>
-#else
-#include "zlib.h"
-#endif
+#include <3rdparty/zlib/zlib.h>
 
 #include <U2Core/IOAdapter.h>
 #include "VirtualOffset.h"

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -4,8 +4,6 @@ UGENE_GLOBALS_DEFINED=1
 
 DEFINES+=U2_DISTRIBUTION_INFO=$${U2_DISTRIBUTION_INFO}
 DEFINES+=UGENE_VERSION=$${UGENE_VERSION}
-DEFINES+=UGENE_MIN_VERSION_SQLITE=$${UGENE_MIN_VERSION_SQLITE}
-DEFINES+=UGENE_MIN_VERSION_MYSQL=$${UGENE_MIN_VERSION_MYSQL}
 DEFINES+=UGENE_VER_MAJOR=$${UGENE_VER_MAJOR}
 DEFINES+=UGENE_VER_MINOR=$${UGENE_VER_MINOR}
 DEFINES+=UGENE_VER_PATCH=$${UGENE_VER_PATCH}
@@ -131,16 +129,17 @@ defineTest( unix_not_mac ) {
 }
 
 
-#By default, UGENE uses bundled zlib (libs_3rdparty/zlib) on windows and mac os.
-#On any OS it can be forced using the following variable
-
-# UGENE_USE_BUNDLED_ZLIB = 1
+# By default, UGENE uses bundled zlib (libs_3rdparty/zlib).
+# To switch to OS default version set UGENE_USE_BUNDLED_ZLIB = 0
 
 defineTest( use_bundled_zlib ) {
     contains( UGENE_USE_BUNDLED_ZLIB, 1 ) : return (true)
     contains( UGENE_USE_BUNDLED_ZLIB, 0 ) : return (false)
-    unix_not_mac() : return (false)
     return (true)
+}
+
+use_bundled_zlib() {
+    DEFINES+=UGENE_USE_BUNDLED_ZLIB
 }
 
 #Variable enabling exclude list for ugene modules


### PR DESCRIPTION
3rd party libs like zlib or sqlite3 are not handled correctly by UGENE build.
The problem is that system's <zlib.h> comes always first and used regardless of UGENE_USE_BUNDLED_ZLIB flag.

This patch:
1) Fixes zlib problem by adding clean separation between system and bundled file

2) Adds initial support for sqlite problem fix. This problem is bigger than zlib's one, because ugenedb dependency is used by multiple module without any checks. For sqlite3 problem additional patch will come.

3) Enables UGENE_USE_BUNDLED_ZLIB for Unix build by default. This mode is better because does not require developer to install any system libraries by default. 
