### PR TITLE
Fixing shadow build errors with qmake

### DIFF
--- a/src/corelibs/U2Core/U2Core.pri
+++ b/src/corelibs/U2Core/U2Core.pri
@@ -63,5 +63,3 @@ unix_not_mac(){
         }
     }
 }
-
-HEADERS += ../../include/U2Core/U2*.h

--- a/src/corelibs/U2Gui/src/util/shared_db/ui/EditConnectionDialog.ui
+++ b/src/corelibs/U2Gui/src/util/shared_db/ui/EditConnectionDialog.ui
@@ -122,7 +122,7 @@
   <customwidget>
    <class>U2::AuthenticationWidget</class>
    <extends>QWidget</extends>
-   <header>../../src/util/AuthenticationWidget.h</header>
+   <header>./util/AuthenticationWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Shadow build is a practical method to build a source tree from different folders without spoiling the source folder with build artifacts.  If properly used all qmake builds support this option. 

This patch fixes issues that blocked shadow build to complete successfully for UGENE.

How to use shadow build
1) Clone UGENE sources to './ugene'
2) Create folder "./ugene-build"
3) From "./ugene-build" run "qmake ../ugene && make"
