### PR TITLE
Fixing shadow build for Windows

### DIFF
--- a/src/libs_3rdparty/sqlite3/sqlite3.pri
+++ b/src/libs_3rdparty/sqlite3/sqlite3.pri
@@ -35,7 +35,7 @@ LIBS += -L../../_release
 
 
 win32 {
-    DEF_FILE=src/sqlite3.def
+    DEF_FILE=$$PWD/src/sqlite3.def
 
     QMAKE_CXXFLAGS_WARN_ON = -W3
     QMAKE_CFLAGS_WARN_ON = -W3


### PR DESCRIPTION
Fixing shadow build for windows.
To use shadow build from an empty dir run these commands:
qmake.exe -r -spec win32-msvc2013 -tp vc ../ugene
MSBuild ugene.sln /t:Rebuild /p:Configuration=Release
